### PR TITLE
Updated FilePicker control to support Uno

### DIFF
--- a/samples/MADE.Samples.Windows/MainPage.xaml.cs
+++ b/samples/MADE.Samples.Windows/MainPage.xaml.cs
@@ -4,10 +4,10 @@ namespace MADE.Samples.Windows
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
-    using Data.Validation;
     using global::Windows.UI.Xaml.Controls;
+    using MADE.Data.Validation;
     using MADE.Data.Validation.Validators;
-    using UI.Controls;
+    using MADE.UI.Controls;
 
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.

--- a/samples/MADE.Samples/MADE.Samples.Droid/MADE.Samples.Droid.csproj
+++ b/samples/MADE.Samples/MADE.Samples.Droid/MADE.Samples.Droid.csproj
@@ -117,6 +117,10 @@
       <Project>{3de798a8-6b5d-457e-a200-67aaf6feae8c}</Project>
       <Name>MADE.Threading</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\src\MADE.UI.Controls.FilePicker\MADE.UI.Controls.FilePicker.csproj">
+      <Project>{774fd8d5-ccc1-4eed-aa14-f7069bfae5ce}</Project>
+      <Name>MADE.UI.Controls.FilePicker</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\src\MADE.UI.Controls.Validator\MADE.UI.Controls.Validator.csproj">
       <Project>{e2b20928-dae2-4a9c-bdaf-d787b4f48391}</Project>
       <Name>MADE.UI.Controls.Validator</Name>

--- a/samples/MADE.Samples/MADE.Samples.Shared/MainPage.xaml
+++ b/samples/MADE.Samples/MADE.Samples.Shared/MainPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="MADE.Samples.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -28,5 +28,16 @@
             RelativePanel.Below="TextBoxValidator">
             <DatePicker x:Name="DatePicker" Header="DatePicker with InputValidator" />
         </controls:InputValidator>
+
+        <controls:FilePicker
+            x:Name="FilePickerControl"
+            Margin="0,12,0,0"
+            AppendFiles="True"
+            Files="{x:Bind FilePickerFiles}"
+            Header="FilePicker"
+            RelativePanel.AlignLeftWithPanel="True"
+            RelativePanel.AlignRightWithPanel="True"
+            RelativePanel.Below="DatePickerValidator"
+            SelectionMode="Multiple" />
     </RelativePanel>
 </Page>

--- a/samples/MADE.Samples/MADE.Samples.Shared/MainPage.xaml.cs
+++ b/samples/MADE.Samples/MADE.Samples.Shared/MainPage.xaml.cs
@@ -1,10 +1,13 @@
 namespace MADE.Samples
 {
     using System;
-
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics;
     using MADE.Data.Validation;
+    using MADE.Data.Validation.Extensions;
     using MADE.Data.Validation.Validators;
-
+    using MADE.UI.Controls;
     using Windows.UI.Xaml.Controls;
 
     /// <summary>
@@ -25,6 +28,10 @@ namespace MADE.Samples
                                                           DateTimeOffset.Now,
                                                           DateTimeOffset.Now.AddDays(7)),
                                                   };
+
+            this.FilePickerControl.ItemClick += (sender, args) => System.Diagnostics.Debug.WriteLine(args.ClickedItem);
         }
+        
+        public ObservableCollection<FilePickerItem> FilePickerFiles { get; } = new ObservableCollection<FilePickerItem>();
     }
 }

--- a/samples/MADE.Samples/MADE.Samples.Wasm/MADE.Samples.Wasm.csproj
+++ b/samples/MADE.Samples/MADE.Samples.Wasm/MADE.Samples.Wasm.csproj
@@ -52,6 +52,7 @@
     <ProjectReference Include="..\..\..\src\MADE.Networking\MADE.Networking.csproj" />
     <ProjectReference Include="..\..\..\src\MADE.Runtime\MADE.Runtime.csproj" />
     <ProjectReference Include="..\..\..\src\MADE.Threading\MADE.Threading.csproj" />
+    <ProjectReference Include="..\..\..\src\MADE.UI.Controls.FilePicker\MADE.UI.Controls.FilePicker.csproj" />
     <ProjectReference Include="..\..\..\src\MADE.UI.Controls.Validator\MADE.UI.Controls.Validator.csproj" />
     <ProjectReference Include="..\..\..\src\MADE.UI\MADE.UI.csproj" />
   </ItemGroup>

--- a/samples/MADE.Samples/MADE.Samples.iOS/MADE.Samples.iOS.csproj
+++ b/samples/MADE.Samples/MADE.Samples.iOS/MADE.Samples.iOS.csproj
@@ -179,6 +179,10 @@
       <Project>{3de798a8-6b5d-457e-a200-67aaf6feae8c}</Project>
       <Name>MADE.Threading</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\src\MADE.UI.Controls.FilePicker\MADE.UI.Controls.FilePicker.csproj">
+      <Project>{774fd8d5-ccc1-4eed-aa14-f7069bfae5ce}</Project>
+      <Name>MADE.UI.Controls.FilePicker</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\src\MADE.UI.Controls.Validator\MADE.UI.Controls.Validator.csproj">
       <Project>{e2b20928-dae2-4a9c-bdaf-d787b4f48391}</Project>
       <Name>MADE.UI.Controls.Validator</Name>

--- a/src/MADE.Collections/MADE.Collections.csproj
+++ b/src/MADE.Collections/MADE.Collections.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>uap10.0.17763;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Product>MADE.NET Collections</Product>
     <Description>

--- a/src/MADE.UI.Controls.DropDownList/MADE.UI.Controls.DropDownList.csproj
+++ b/src/MADE.UI.Controls.DropDownList/MADE.UI.Controls.DropDownList.csproj
@@ -10,7 +10,7 @@
     </Description>
     <PackageTags>MADE UI Views Controls UWP DropDown List Multiselect</PackageTags>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
-    <RootNamespace>MADE.UI.Controls</RootNamespace>
+    <RootNamespace>MADE.UI.Controls.DropDownListControl</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Controls.FilePicker/FilePicker.cs
+++ b/src/MADE.UI.Controls.FilePicker/FilePicker.cs
@@ -22,7 +22,7 @@ namespace MADE.UI.Controls
     [TemplatePart(Name = FilePickerChooseFileButtonPart, Type = typeof(Button))]
     [TemplatePart(Name = FilePickerItemsViewPart, Type = typeof(ListViewBase))]
     [TemplatePart(Name = FilePickerHeaderPresenterPart, Type = typeof(ContentPresenter))]
-    public class FilePicker : Control, IFilePicker
+    public partial class FilePicker : Control, IFilePicker
     {
         private const string FilePickerChooseFileButtonPart = "FilePickerChooseFileButton";
 

--- a/src/MADE.UI.Controls.FilePicker/FilePickerItem.cs
+++ b/src/MADE.UI.Controls.FilePicker/FilePickerItem.cs
@@ -55,8 +55,13 @@ namespace MADE.UI.Controls
         {
             if (this.File != null)
             {
-                StorageItemThumbnail thumbnail =
-                    await this.File.GetThumbnailAsync(ThumbnailMode.SingleItem, 256, ThumbnailOptions.ResizeThumbnail);
+                StorageItemThumbnail thumbnail;
+
+#if WINDOWS_UWP
+                thumbnail = await this.File.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.SingleItem, 256, ThumbnailOptions.ResizeThumbnail);
+#else
+                thumbnail = null;
+#endif
 
                 if (thumbnail == null)
                 {

--- a/src/MADE.UI.Controls.FilePicker/MADE.UI.Controls.FilePicker.csproj
+++ b/src/MADE.UI.Controls.FilePicker/MADE.UI.Controls.FilePicker.csproj
@@ -1,17 +1,21 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>uap10.0.17763</TargetFramework>
+    <TargetFrameworks>uap10.0.17763;MonoAndroid10.0;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Product>MADE.NET UI FilePicker Control</Product>
     <Description>
-      This package includes UI components for UWP such as:
+      This package includes UI components for Windows and Uno Platform such as:
       - FilePicker providing an input control that allows a user to pick files.
     </Description>
-    <PackageTags>MADE UI Views Controls UWP FilePicker Input File</PackageTags>
+    <PackageTags>MADE UI Views Controls FilePicker Input File Windows Android iOS macOS Xamarin Uno</PackageTags>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
-    <RootNamespace>MADE.UI.Controls</RootNamespace>
+    <RootNamespace>MADE.UI.Controls.FilePickerControl</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
+    <PackageReference Include="Uno.UI" Version="3.6.6" />
+  </ItemGroup>
 
   <ItemGroup>
     <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml">

--- a/src/MADE.UI.Controls.Validator/MADE.UI.Controls.Validator.csproj
+++ b/src/MADE.UI.Controls.Validator/MADE.UI.Controls.Validator.csproj
@@ -5,12 +5,12 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Product>MADE.NET UI DropDownList Control</Product>
     <Description>
-      This package includes UI components for UWP such as:
+      This package includes UI components for Windows and Uno Platform such as:
       - Validator providing a wrapper for content to provide validation over input controls.
     </Description>
-    <PackageTags>MADE UI Views Controls UWP Validator Validation</PackageTags>
+    <PackageTags>MADE UI Views Controls Validator Validation Windows Android iOS macOS Xamarin Uno</PackageTags>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
-    <RootNamespace>MADE.UI.Controls</RootNamespace>
+    <RootNamespace>MADE.UI.Controls.ValidatorControl</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">


### PR DESCRIPTION
## Fixes #120 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Added Uno support for the FilePicker control. The thumbnail APIs for storage files aren't supported so this code has been conditionally removed for everything but Windows for now. 

## PR checklist

- [x] Samples have been added/updated (where applicable)
- [ ] Tests have been added/updated (where applicable) and pass
- [ ] Documentation has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes