### PR TITLE
Alteration to mark Windows specifics as Obsolete

### DIFF
--- a/src/MADE.Data.Converters/BooleanToStringValueConverter.Windows.cs
+++ b/src/MADE.Data.Converters/BooleanToStringValueConverter.Windows.cs
@@ -13,6 +13,7 @@ namespace MADE.Data.Converters
     /// <summary>
     /// Defines a Windows components for a XAML value converter from <see cref="bool"/> to <see cref="string"/>.
     /// </summary>
+    [Obsolete("Use the replicated BooleanToStringValueConverter type from the MADE.UI.Data.Converters library instead.")]
     public class BooleanToStringValueConverter : DependencyObject, IValueConverter, IValueConverter<bool, string>
     {
         /// <summary>

--- a/src/MADE.Data.Converters/BooleanToStringValueConverter.Windows.cs
+++ b/src/MADE.Data.Converters/BooleanToStringValueConverter.Windows.cs
@@ -5,7 +5,6 @@
 namespace MADE.Data.Converters
 {
     using System;
-    using MADE.Data.Converters.Exceptions;
     using MADE.Data.Converters.Strings;
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Data;
@@ -13,8 +12,8 @@ namespace MADE.Data.Converters
     /// <summary>
     /// Defines a Windows components for a XAML value converter from <see cref="bool"/> to <see cref="string"/>.
     /// </summary>
-    [Obsolete("Use the replicated BooleanToStringValueConverter type from the MADE.UI.Data.Converters library instead.")]
-    public class BooleanToStringValueConverter : DependencyObject, IValueConverter, IValueConverter<bool, string>
+    [Obsolete("BooleanToStringValueConverter for Windows will be removed in a future major release. Use the replicated BooleanToStringValueConverter type from the MADE.UI.Data.Converters library instead.")]
+    public partial class BooleanToStringValueConverter : DependencyObject, IValueConverter, IValueConverter<bool, string>
     {
         /// <summary>
         /// Defines the dependency property for <see cref="TrueValue"/>.
@@ -87,50 +86,6 @@ namespace MADE.Data.Converters
             }
 
             return this.ConvertBack(b, parameter);
-        }
-
-        /// <summary>
-        /// Converts the <paramref name="value">value</paramref> to the <see cref="string"/> type.
-        /// </summary>
-        /// <param name="value">
-        /// The value to convert.
-        /// </param>
-        /// <param name="parameter">
-        /// The optional parameter used to help with conversion.
-        /// </param>
-        /// <returns>
-        /// The converted <see cref="string"/> object.
-        /// </returns>
-        public string Convert(bool value, object parameter = default)
-        {
-            return value ? this.TrueValue : this.FalseValue;
-        }
-
-        /// <summary>
-        /// Converts the <paramref name="value">value</paramref> back to the <see cref="bool"/> type.
-        /// </summary>
-        /// <param name="value">
-        /// The value to convert.
-        /// </param>
-        /// <param name="parameter">
-        /// The optional parameter used to help with conversion.
-        /// </param>
-        /// <returns>
-        /// The converted <see cref="bool"/> object.
-        /// </returns>
-        public bool ConvertBack(string value, object parameter = default)
-        {
-            if (value == this.TrueValue)
-            {
-                return true;
-            }
-
-            if (value == this.FalseValue)
-            {
-                return false;
-            }
-
-            throw new InvalidDataConversionException(nameof(BooleanToStringValueConverter), value, $"The value to convert back is not of the expected {nameof(this.TrueValue)} or {nameof(this.FalseValue)}");
         }
     }
 }

--- a/src/MADE.Data.Converters/BooleanToStringValueConverter.cs
+++ b/src/MADE.Data.Converters/BooleanToStringValueConverter.cs
@@ -1,0 +1,66 @@
+namespace MADE.Data.Converters
+{
+    using MADE.Data.Converters.Exceptions;
+
+    /// <summary>
+    /// Defines a value converter from <see cref="bool"/> to <see cref="string"/> with a pre-determined <see cref="TrueValue"/> and <see cref="FalseValue"/>.
+    /// </summary>
+    public partial class BooleanToStringValueConverter : IValueConverter<bool, string>
+    {
+#if !WINDOWS_UWP
+        /// <summary>
+        /// Gets or sets the positive/true value.
+        /// </summary>
+        public string TrueValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the negative/false value.
+        /// </summary>
+        public string FalseValue { get; set; }
+#endif
+
+        /// <summary>
+        /// Converts the <paramref name="value">value</paramref> to the <see cref="string"/> type.
+        /// </summary>
+        /// <param name="value">
+        /// The value to convert.
+        /// </param>
+        /// <param name="parameter">
+        /// The optional parameter used to help with conversion.
+        /// </param>
+        /// <returns>
+        /// The converted <see cref="string"/> object.
+        /// </returns>
+        public string Convert(bool value, object parameter = default)
+        {
+            return value ? this.TrueValue : this.FalseValue;
+        }
+
+        /// <summary>
+        /// Converts the <paramref name="value">value</paramref> back to the <see cref="bool"/> type.
+        /// </summary>
+        /// <param name="value">
+        /// The value to convert.
+        /// </param>
+        /// <param name="parameter">
+        /// The optional parameter used to help with conversion.
+        /// </param>
+        /// <returns>
+        /// The converted <see cref="bool"/> object.
+        /// </returns>
+        public bool ConvertBack(string value, object parameter = default)
+        {
+            if (value == this.TrueValue)
+            {
+                return true;
+            }
+
+            if (value == this.FalseValue)
+            {
+                return false;
+            }
+
+            throw new InvalidDataConversionException(nameof(BooleanToStringValueConverter), value, $"The value to convert back is not of the expected {nameof(this.TrueValue)} or {nameof(this.FalseValue)}");
+        }
+    }
+}

--- a/src/MADE.Data.Converters/BooleanToStringValueConverter.cs
+++ b/src/MADE.Data.Converters/BooleanToStringValueConverter.cs
@@ -1,6 +1,7 @@
 namespace MADE.Data.Converters
 {
     using MADE.Data.Converters.Exceptions;
+    using MADE.Data.Converters.Extensions;
 
     /// <summary>
     /// Defines a value converter from <see cref="bool"/> to <see cref="string"/> with a pre-determined <see cref="TrueValue"/> and <see cref="FalseValue"/>.
@@ -33,7 +34,7 @@ namespace MADE.Data.Converters
         /// </returns>
         public string Convert(bool value, object parameter = default)
         {
-            return value ? this.TrueValue : this.FalseValue;
+            return value.ToFormattedString(this.TrueValue, this.FalseValue);
         }
 
         /// <summary>

--- a/src/MADE.Data.Converters/DateTimeToStringValueConverter.Windows.cs
+++ b/src/MADE.Data.Converters/DateTimeToStringValueConverter.Windows.cs
@@ -10,6 +10,7 @@ namespace MADE.Data.Converters
     /// <summary>
     /// Defines a Windows components for a XAML value converter from <see cref="DateTime"/> to <see cref="string"/> with an optional format string.
     /// </summary>
+    [Obsolete("Use the replicated DateTimeToStringValueConverter type from the MADE.UI.Data.Converters library instead.")]
     public partial class DateTimeToStringValueConverter : IValueConverter
     {
         /// <summary>

--- a/src/MADE.Data.Converters/DateTimeToStringValueConverter.Windows.cs
+++ b/src/MADE.Data.Converters/DateTimeToStringValueConverter.Windows.cs
@@ -10,7 +10,7 @@ namespace MADE.Data.Converters
     /// <summary>
     /// Defines a Windows components for a XAML value converter from <see cref="DateTime"/> to <see cref="string"/> with an optional format string.
     /// </summary>
-    [Obsolete("Use the replicated DateTimeToStringValueConverter type from the MADE.UI.Data.Converters library instead.")]
+    [Obsolete("DateTimeToStringValueConverter for Windows will be removed in a future major release. Use the replicated DateTimeToStringValueConverter type from the MADE.UI.Data.Converters library instead.")]
     public partial class DateTimeToStringValueConverter : IValueConverter
     {
         /// <summary>

--- a/src/MADE.Data.Converters/Extensions/BooleanExtensions.cs
+++ b/src/MADE.Data.Converters/Extensions/BooleanExtensions.cs
@@ -1,0 +1,40 @@
+// MADE Apps licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MADE.Data.Converters.Extensions
+{
+    /// <summary>
+    /// Defines a collection of extensions for <see cref="bool"/> values.
+    /// </summary>
+    public static class BooleanExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="bool"/> value to a <see cref="string"/> value with optional true/false values.
+        /// </summary>
+        /// <param name="value">The <see cref="bool"/> value to format.</param>
+        /// <param name="trueValue">The <see cref="string"/> format for when the <paramref name="value"/> is <c>true</c>.</param>
+        /// <param name="falseValue">The <see cref="string"/> format for when the <paramref name="value"/> is <c>false</c>.</param>
+        /// <returns>A formatted string</returns>
+        public static string ToFormattedString(this bool value, string trueValue = "True", string falseValue = "False")
+        {
+            return value ? trueValue : falseValue;
+        }
+
+        /// <summary>
+        /// Converts a nullable <see cref="bool"/> value to a <see cref="string"/> value with optional true/false/null values.
+        /// </summary>
+        /// <param name="value">The <see cref="bool"/> value to format.</param>
+        /// <param name="trueValue">The <see cref="string"/> format for when the <paramref name="value"/> is <c>true</c>. Default, True.</param>
+        /// <param name="falseValue">The <see cref="string"/> format for when the <paramref name="value"/> is <c>false</c>. Default, False.</param>
+        /// <param name="nullValue">The <see cref="string"/> format for when the <paramref name="value"/> is <c>null</c>. Default, Not set.</param>
+        /// <returns>A formatted string</returns>
+        public static string ToFormattedString(
+            this bool? value,
+            string trueValue = "True",
+            string falseValue = "False",
+            string nullValue = "Not set")
+        {
+            return value.HasValue ? value.Value ? trueValue : falseValue : nullValue;
+        }
+    }
+}

--- a/tests/MADE.Data.Converters.Tests/Tests/BooleanExtensionsTests.cs
+++ b/tests/MADE.Data.Converters.Tests/Tests/BooleanExtensionsTests.cs
@@ -1,0 +1,88 @@
+namespace MADE.Data.Converters.Tests.Tests
+{
+    using System.Diagnostics.CodeAnalysis;
+    using MADE.Data.Converters.Extensions;
+    using NUnit.Framework;
+    using Shouldly;
+
+    [ExcludeFromCodeCoverage]
+    [TestFixture]
+    public class BooleanExtensionsTests
+    {
+        public class WhenConvertingBooleanToFormattedString
+        {
+            [Test]
+            public void ShouldReturnTrueValueIfTrue()
+            {
+                // Arrange
+                const bool boolean = true;
+                const string expected = "Yes";
+
+                // Act
+                string formatted = boolean.ToFormattedString(expected, "No");
+
+                // Assert
+                formatted.ShouldBe(expected);
+            }
+
+            [Test]
+            public void ShouldReturnFalseValueIfFalse()
+            {
+                // Arrange
+                const bool boolean = false;
+                const string expected = "No";
+
+                // Act
+                string formatted = boolean.ToFormattedString("Yes", expected);
+
+                // Assert
+                formatted.ShouldBe(expected);
+            }
+        }
+
+        public class WhenConvertingNullableBooleanToFormattedString
+        {
+            [Test]
+            public void ShouldReturnTrueValueIfTrue()
+            {
+                // Arrange
+                bool? boolean = true;
+                const string expected = "Yes";
+
+                // Act
+                string formatted = boolean.ToFormattedString(expected, "No", "N/A");
+
+                // Assert
+                formatted.ShouldBe(expected);
+            }
+
+            [Test]
+            public void ShouldReturnFalseValueIfFalse()
+            {
+                // Arrange
+                bool? boolean = false;
+                const string expected = "No";
+
+                // Act
+                string formatted = boolean.ToFormattedString("Yes", expected, "N/A");
+
+                // Assert
+                formatted.ShouldBe(expected);
+            }
+
+            [Test]
+            public void ShouldReturnNullValueIfNull()
+            {
+                // Arrange
+                bool? boolean = null;
+                const string expected = "N/A";
+
+                // Act
+                string formatted = boolean.ToFormattedString("Yes", "No", expected);
+
+                // Assert
+                formatted.ShouldBe(expected);
+            }
+        }
+    }
+}

--- a/tests/MADE.Data.Converters.Tests/Tests/BooleanToStringValueConverterTests.cs
+++ b/tests/MADE.Data.Converters.Tests/Tests/BooleanToStringValueConverterTests.cs
@@ -1,0 +1,94 @@
+namespace MADE.Data.Converters.Tests.Tests
+{
+    using System.Diagnostics.CodeAnalysis;
+    using MADE.Data.Converters.Exceptions;
+    using NUnit.Framework;
+
+    using Shouldly;
+
+    [ExcludeFromCodeCoverage]
+    [TestFixture]
+    public class BooleanToStringValueConverterTests
+    {
+        public class WhenConverting
+        {
+            [Test]
+            public void ShouldConvertToTrueValueWhenTrue()
+            {
+                // Arrange
+                const bool boolean = true;
+                const string expected = "Yes";
+
+                var converter = new BooleanToStringValueConverter {TrueValue = expected, FalseValue = "No"};
+
+                // Act
+                string converted = converter.Convert(boolean);
+
+                // Assert
+                converted.ShouldBe(expected);
+            }
+
+            [Test]
+            public void ShouldConvertToFalseValueWhenFalse()
+            {
+                const bool boolean = false;
+                const string expected = "No";
+
+                var converter = new BooleanToStringValueConverter {TrueValue = "Yes", FalseValue = expected};
+
+                // Act
+                string converted = converter.Convert(boolean);
+
+                // Assert
+                converted.ShouldBe(expected);
+            }
+        }
+
+        public class WhenConvertingBack
+        {
+            [Test]
+            public void ShouldConvertToTrueWhenTrueValue()
+            {
+                // Arrange
+                const string booleanString = "Yes";
+                const bool expected = true;
+
+                var converter = new BooleanToStringValueConverter {TrueValue = booleanString, FalseValue = "No"};
+
+                // Act
+                bool converted = converter.ConvertBack(booleanString);
+
+                // Assert
+                converted.ShouldBe(expected);
+            }
+
+            [Test]
+            public void ShouldConvertToFalseWhenFalseValue()
+            {
+                // Arrange
+                const string booleanString = "No";
+                const bool expected = false;
+
+                var converter = new BooleanToStringValueConverter {TrueValue = "Yes", FalseValue = booleanString};
+
+                // Act
+                bool converted = converter.ConvertBack(booleanString);
+
+                // Assert
+                converted.ShouldBe(expected);
+            }
+
+            [Test]
+            public void ShouldThrowInvalidDataConversionExceptionIfNotTrueOrFalseValue()
+            {
+                // Arrange
+                const string booleanString = "Not valid";
+
+                var converter = new BooleanToStringValueConverter {TrueValue = "Yes", FalseValue = "No"};
+
+                // Act & Assert
+                Should.Throw<InvalidDataConversionException>(() => converter.ConvertBack(booleanString));
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to split out the non-platform specific logic from the `BooleanToStringValueConverter` and mark the Windows specific components as Obsolete in favor of the `MADE.UI` alternative.

## PR checklist

- [ ] Samples have been added/updated (where applicable)
- [x] Tests have been added/updated (where applicable) and pass
- [ ] Documentation has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
