### PR TITLE
ci: cancel superseded PR workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ on:
     - global.json
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,10 @@ on:
     - .github/workflows/docs.yml
   workflow_dispatch:
 
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: write
 


### PR DESCRIPTION
This pull request adds concurrency controls to the GitHub Actions workflows for both CI and documentation. These changes help prevent multiple runs of the same workflow from overlapping and ensure that only the latest run for a given branch (except `main`) is executed.

**Workflow concurrency improvements:**

* Added a `concurrency` group to `.github/workflows/ci.yml` to group CI runs by branch and cancel in-progress runs for non-`main` branches.
* Added a `concurrency` group to `.github/workflows/docs.yml` to group documentation workflow runs by branch and cancel in-progress runs for non-`main` branches.