### PR TITLE
fix: resolve Timer.Start dueTime bugs and hardening

### DIFF
--- a/MADE.NET.sln
+++ b/MADE.NET.sln
@@ -1,5 +1,4 @@
-
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/MADE.NET.sln
+++ b/MADE.NET.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32228.430
@@ -58,6 +58,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MADE.Testing.Tests", "tests\MADE.Testing.Tests\MADE.Testing.Tests.csproj", "{40B5F4EB-45DD-410A-B0FB-2384C863FC33}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MADE.Web.Mvc.Tests", "tests\MADE.Web.Mvc.Tests\MADE.Web.Mvc.Tests.csproj", "{F994F941-474A-4FDD-A9CB-280EB0D78407}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MADE.Foundation.Tests", "tests\MADE.Foundation.Tests\MADE.Foundation.Tests.csproj", "{EE7B8716-5B54-45EC-91AD-4764F4AC863B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MADE.Runtime.Tests", "tests\MADE.Runtime.Tests\MADE.Runtime.Tests.csproj", "{D360BA13-4DAD-4C62-AE4A-737553F34E01}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -169,6 +173,14 @@ Global
 		{F994F941-474A-4FDD-A9CB-280EB0D78407}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F994F941-474A-4FDD-A9CB-280EB0D78407}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F994F941-474A-4FDD-A9CB-280EB0D78407}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE7B8716-5B54-45EC-91AD-4764F4AC863B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE7B8716-5B54-45EC-91AD-4764F4AC863B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE7B8716-5B54-45EC-91AD-4764F4AC863B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE7B8716-5B54-45EC-91AD-4764F4AC863B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D360BA13-4DAD-4C62-AE4A-737553F34E01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D360BA13-4DAD-4C62-AE4A-737553F34E01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D360BA13-4DAD-4C62-AE4A-737553F34E01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D360BA13-4DAD-4C62-AE4A-737553F34E01}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -200,6 +212,8 @@ Global
 		{865FBD49-C64B-4B36-AEFC-FD960DDC4CF8} = {69149D0F-BB09-411B-88F0-A1E845058D70}
 		{40B5F4EB-45DD-410A-B0FB-2384C863FC33} = {69149D0F-BB09-411B-88F0-A1E845058D70}
 		{F994F941-474A-4FDD-A9CB-280EB0D78407} = {69149D0F-BB09-411B-88F0-A1E845058D70}
+		{EE7B8716-5B54-45EC-91AD-4764F4AC863B} = {69149D0F-BB09-411B-88F0-A1E845058D70}
+		{D360BA13-4DAD-4C62-AE4A-737553F34E01} = {69149D0F-BB09-411B-88F0-A1E845058D70}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3921AD86-E6C0-4436-8880-2D9EDFAD6151}

--- a/src/MADE.Diagnostics/AppDiagnostics.cs
+++ b/src/MADE.Diagnostics/AppDiagnostics.cs
@@ -78,38 +78,52 @@ public class AppDiagnostics : IAppDiagnostics
 
     private async void OnTaskUnobservedException(object? sender, UnobservedTaskExceptionEventArgs args)
     {
-        args.SetObserved();
-
-        var correlationId = Guid.NewGuid();
-
-        await this.EventLogger.WriteCritical(
-            args.Exception != null
-                ? $"An unobserved task exception was thrown. Correlation ID: {correlationId}. Error: {args.Exception}."
-                : $"An unobserved task exception was thrown. Correlation ID: {correlationId}. Error: No exception information was available.").ConfigureAwait(false);
-
-        if (args.Exception != null)
+        try
         {
-            this.ExceptionObserved?.Invoke(this, new ExceptionObservedEventArgs(correlationId, args.Exception));
+            args.SetObserved();
+
+            var correlationId = Guid.NewGuid();
+
+            await this.EventLogger.WriteCritical(
+                args.Exception != null
+                    ? $"An unobserved task exception was thrown. Correlation ID: {correlationId}. Error: {args.Exception}."
+                    : $"An unobserved task exception was thrown. Correlation ID: {correlationId}. Error: No exception information was available.").ConfigureAwait(false);
+
+            if (args.Exception != null)
+            {
+                this.ExceptionObserved?.Invoke(this, new ExceptionObservedEventArgs(correlationId, args.Exception));
+            }
+        }
+        catch
+        {
+            // Swallow exceptions in last-resort exception handlers to prevent crashing the process.
         }
     }
 
     private async void OnAppUnhandledException(object sender, UnhandledExceptionEventArgs args)
     {
-        if (args.IsTerminating)
+        try
         {
-            await this.EventLogger.WriteCritical(
-                "The application is terminating due to an unhandled exception being thrown.").ConfigureAwait(false);
-        }
+            if (args.IsTerminating)
+            {
+                await this.EventLogger.WriteCritical(
+                    "The application is terminating due to an unhandled exception being thrown.").ConfigureAwait(false);
+            }
 
-        if (args.ExceptionObject is not Exception ex)
+            if (args.ExceptionObject is not Exception ex)
+            {
+                return;
+            }
+
+            var correlationId = Guid.NewGuid();
+
+            await this.EventLogger.WriteCritical($"An unhandled exception was thrown. Correlation ID: {correlationId}. Error: {ex}").ConfigureAwait(false);
+
+            this.ExceptionObserved?.Invoke(this, new ExceptionObservedEventArgs(correlationId, ex));
+        }
+        catch
         {
-            return;
+            // Swallow exceptions in last-resort exception handlers to prevent crashing the process.
         }
-
-        var correlationId = Guid.NewGuid();
-
-        await this.EventLogger.WriteCritical($"An unhandled exception was thrown. Correlation ID: {correlationId}. Error: {ex}").ConfigureAwait(false);
-
-        this.ExceptionObserved?.Invoke(this, new ExceptionObservedEventArgs(correlationId, ex));
     }
 }

--- a/src/MADE.Diagnostics/AppDiagnostics.cs
+++ b/src/MADE.Diagnostics/AppDiagnostics.cs
@@ -94,7 +94,7 @@ public class AppDiagnostics : IAppDiagnostics
                 this.ExceptionObserved?.Invoke(this, new ExceptionObservedEventArgs(correlationId, args.Exception));
             }
         }
-        catch
+        catch (Exception)
         {
             // Swallow exceptions in last-resort exception handlers to prevent crashing the process.
         }
@@ -121,7 +121,7 @@ public class AppDiagnostics : IAppDiagnostics
 
             this.ExceptionObserved?.Invoke(this, new ExceptionObservedEventArgs(correlationId, ex));
         }
-        catch
+        catch (Exception)
         {
             // Swallow exceptions in last-resort exception handlers to prevent crashing the process.
         }

--- a/src/MADE.Networking/Extensions/UriExtensions.cs
+++ b/src/MADE.Networking/Extensions/UriExtensions.cs
@@ -17,7 +17,7 @@ public static class UriExtensions
     /// <param name="uri">The <see cref="Uri"/> to extract a query value from.</param>
     /// <param name="queryParam">The key of the parameter in the query to extract the value for.</param>
     /// <returns>The value for the query parameter.</returns>
-    public static string GetQueryValue(this Uri uri, string queryParam)
+    public static string? GetQueryValue(this Uri uri, string queryParam)
     {
         NameValueCollection queryDictionary = System.Web.HttpUtility.ParseQueryString(uri.Query);
         return queryDictionary.Get(queryParam);

--- a/src/MADE.Networking/Http/INetworkRequestManager.cs
+++ b/src/MADE.Networking/Http/INetworkRequestManager.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using MADE.Networking.Http.Requests;
 
 namespace MADE.Networking.Http;
@@ -100,5 +101,6 @@ public interface INetworkRequestManager
     /// <summary>
     /// Processes the current queue of network requests.
     /// </summary>
-    void ProcessCurrentQueue();
+    /// <returns>An asynchronous operation.</returns>
+    Task ProcessCurrentQueueAsync();
 }

--- a/src/MADE.Networking/Http/NetworkRequestFactory.cs
+++ b/src/MADE.Networking/Http/NetworkRequestFactory.cs
@@ -33,43 +33,43 @@ public class NetworkRequestFactory : INetworkRequestFactory
     /// <inheritdoc/>
     public JsonGetNetworkRequest Get(string url, Dictionary<string, string>? headers = null)
     {
-        return new JsonGetNetworkRequest(this.CreateClient(), url, headers!);
+        return new JsonGetNetworkRequest(this.CreateClient(), url, headers);
     }
 
     /// <inheritdoc/>
     public JsonPostNetworkRequest Post(string url, string? jsonData = null, Dictionary<string, string>? headers = null)
     {
-        return new JsonPostNetworkRequest(this.CreateClient(), url, jsonData!, headers!);
+        return new JsonPostNetworkRequest(this.CreateClient(), url, jsonData, headers);
     }
 
     /// <inheritdoc/>
     public JsonPutNetworkRequest Put(string url, string? jsonData = null, Dictionary<string, string>? headers = null)
     {
-        return new JsonPutNetworkRequest(this.CreateClient(), url, jsonData!, headers!);
+        return new JsonPutNetworkRequest(this.CreateClient(), url, jsonData, headers);
     }
 
     /// <inheritdoc/>
     public JsonPatchNetworkRequest Patch(string url, string? jsonData = null, Dictionary<string, string>? headers = null)
     {
-        return new JsonPatchNetworkRequest(this.CreateClient(), url, jsonData!, headers!);
+        return new JsonPatchNetworkRequest(this.CreateClient(), url, jsonData, headers);
     }
 
     /// <inheritdoc/>
     public JsonDeleteNetworkRequest Delete(string url, Dictionary<string, string>? headers = null)
     {
-        return new JsonDeleteNetworkRequest(this.CreateClient(), url, headers!);
+        return new JsonDeleteNetworkRequest(this.CreateClient(), url, headers);
     }
 
     /// <inheritdoc/>
     public StreamGetNetworkRequest GetStream(string url, Dictionary<string, string>? headers = null)
     {
-        return new StreamGetNetworkRequest(this.CreateClient(), url, headers!);
+        return new StreamGetNetworkRequest(this.CreateClient(), url, headers);
     }
 
     /// <inheritdoc/>
     public MultipartFormDataPostNetworkRequest PostMultipart(string url, Dictionary<string, string>? headers = null)
     {
-        return new MultipartFormDataPostNetworkRequest(this.CreateClient(), url, headers!);
+        return new MultipartFormDataPostNetworkRequest(this.CreateClient(), url, headers);
     }
 
     /// <inheritdoc/>

--- a/src/MADE.Networking/Http/NetworkRequestManager.cs
+++ b/src/MADE.Networking/Http/NetworkRequestManager.cs
@@ -84,7 +84,8 @@ public sealed class NetworkRequestManager : INetworkRequestManager, IDisposable
     /// <summary>
     /// Processes the current queue of network requests.
     /// </summary>
-    public void ProcessCurrentQueue()
+    /// <returns>An asynchronous operation.</returns>
+    public async Task ProcessCurrentQueueAsync()
     {
         if (this.CurrentQueue.Count == 0 || this.isProcessingRequests)
         {
@@ -102,13 +103,13 @@ public sealed class NetworkRequestManager : INetworkRequestManager, IDisposable
             {
                 if (this.CurrentQueue.TryRemove(
                         this.CurrentQueue.FirstOrDefault().Key,
-                        out NetworkRequestCallback request))
+                        out NetworkRequestCallback? request))
                 {
                     requestTasks.Add(ExecuteRequestsAsync(this.CurrentQueue, request, cts.Token));
                 }
             }
 
-            Task.WhenAll(requestTasks).GetAwaiter().GetResult();
+            await Task.WhenAll(requestTasks).ConfigureAwait(false);
         }
         finally
         {
@@ -220,23 +221,39 @@ public sealed class NetworkRequestManager : INetworkRequestManager, IDisposable
         }
 
         NetworkRequest request = requestCallback.Request;
-        WeakReferenceCallback successCallback = requestCallback.SuccessCallback;
-        WeakReferenceCallback errorCallback = requestCallback.ErrorCallback;
+        WeakReferenceCallback? successCallback = requestCallback.SuccessCallback;
+        WeakReferenceCallback? errorCallback = requestCallback.ErrorCallback;
 
         try
         {
+            if (successCallback is null)
+            {
+                return;
+            }
+
             object response = await request.ExecuteAsync(successCallback.Type, cancellationToken).ConfigureAwait(false);
             successCallback.Invoke(response);
         }
         catch (Exception ex)
         {
-            successCallback.Invoke(Activator.CreateInstance(successCallback.Type));
+            if (successCallback is not null)
+            {
+                successCallback.Invoke(Activator.CreateInstance(successCallback.Type)!);
+            }
+
             errorCallback?.Invoke(ex);
         }
     }
 
-    private void OnProcessTimerTick(object sender, object e)
+    private async void OnProcessTimerTick(object sender, object e)
     {
-        this.ProcessCurrentQueue();
+        try
+        {
+            await this.ProcessCurrentQueueAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // Swallow exceptions in timer callback to prevent unobserved task exceptions.
+        }
     }
 }

--- a/src/MADE.Networking/Http/NetworkRequestManager.cs
+++ b/src/MADE.Networking/Http/NetworkRequestManager.cs
@@ -236,10 +236,7 @@ public sealed class NetworkRequestManager : INetworkRequestManager, IDisposable
         }
         catch (Exception ex)
         {
-            if (successCallback is not null)
-            {
-                successCallback.Invoke(Activator.CreateInstance(successCallback.Type)!);
-            }
+            successCallback.Invoke(Activator.CreateInstance(successCallback.Type)!);
 
             errorCallback?.Invoke(ex);
         }
@@ -251,9 +248,10 @@ public sealed class NetworkRequestManager : INetworkRequestManager, IDisposable
         {
             await this.ProcessCurrentQueueAsync().ConfigureAwait(false);
         }
-        catch
+        catch (Exception)
         {
-            // Swallow exceptions in timer callback to prevent unobserved task exceptions.
+            // Swallow exceptions in the async void timer callback to prevent them from
+            // escaping as unhandled exceptions and crashing the process.
         }
     }
 }

--- a/src/MADE.Networking/Http/Requests/Json/JsonDeleteNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonDeleteNetworkRequest.cs
@@ -66,7 +66,8 @@ public sealed class JsonDeleteNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {typeof(TResponse).Name}.");
     }
 
     /// <summary>
@@ -86,7 +87,8 @@ public sealed class JsonDeleteNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {expectedResponse.Name}.");
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)

--- a/src/MADE.Networking/Http/Requests/Json/JsonDeleteNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonDeleteNetworkRequest.cs
@@ -15,6 +15,8 @@ namespace MADE.Networking.Http.Requests.Json;
 /// </summary>
 public sealed class JsonDeleteNetworkRequest : NetworkRequest
 {
+    private static readonly JsonSerializerOptions DefaultJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
     private readonly HttpClient client;
 
     /// <summary>
@@ -43,7 +45,7 @@ public sealed class JsonDeleteNetworkRequest : NetworkRequest
     /// <param name="headers">
     /// The additional headers.
     /// </param>
-    public JsonDeleteNetworkRequest(HttpClient client, string url, Dictionary<string, string> headers)
+    public JsonDeleteNetworkRequest(HttpClient client, string url, Dictionary<string, string>? headers)
         : base(url, headers)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));
@@ -64,7 +66,7 @@ public sealed class JsonDeleteNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
     }
 
     /// <summary>
@@ -84,7 +86,7 @@ public sealed class JsonDeleteNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)
@@ -118,6 +120,6 @@ public sealed class JsonDeleteNetworkRequest : NetworkRequest
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/MADE.Networking/Http/Requests/Json/JsonGetNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonGetNetworkRequest.cs
@@ -15,6 +15,8 @@ namespace MADE.Networking.Http.Requests.Json;
 /// </summary>
 public sealed class JsonGetNetworkRequest : NetworkRequest
 {
+    private static readonly JsonSerializerOptions DefaultJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
     private readonly HttpClient client;
 
     /// <summary>
@@ -43,7 +45,7 @@ public sealed class JsonGetNetworkRequest : NetworkRequest
     /// <param name="headers">
     /// The additional headers.
     /// </param>
-    public JsonGetNetworkRequest(HttpClient client, string url, Dictionary<string, string> headers)
+    public JsonGetNetworkRequest(HttpClient client, string url, Dictionary<string, string>? headers)
         : base(url, headers)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));
@@ -64,7 +66,7 @@ public sealed class JsonGetNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
     }
 
     /// <summary>
@@ -84,7 +86,7 @@ public sealed class JsonGetNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)
@@ -118,6 +120,6 @@ public sealed class JsonGetNetworkRequest : NetworkRequest
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/MADE.Networking/Http/Requests/Json/JsonGetNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonGetNetworkRequest.cs
@@ -66,7 +66,8 @@ public sealed class JsonGetNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {typeof(TResponse).Name}.");
     }
 
     /// <summary>
@@ -86,7 +87,8 @@ public sealed class JsonGetNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {expectedResponse.Name}.");
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)

--- a/src/MADE.Networking/Http/Requests/Json/JsonPatchNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonPatchNetworkRequest.cs
@@ -16,6 +16,8 @@ namespace MADE.Networking.Http.Requests.Json;
 /// </summary>
 public sealed class JsonPatchNetworkRequest : NetworkRequest
 {
+    private static readonly JsonSerializerOptions DefaultJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
     private readonly HttpClient client;
 
     /// <summary>
@@ -44,7 +46,7 @@ public sealed class JsonPatchNetworkRequest : NetworkRequest
     /// <param name="jsonData">
     /// The JSON data to post.
     /// </param>
-    public JsonPatchNetworkRequest(HttpClient client, string url, string jsonData)
+    public JsonPatchNetworkRequest(HttpClient client, string url, string? jsonData)
         : this(client, url, jsonData, null)
     {
     }
@@ -67,8 +69,8 @@ public sealed class JsonPatchNetworkRequest : NetworkRequest
     public JsonPatchNetworkRequest(
         HttpClient client,
         string url,
-        string jsonData,
-        Dictionary<string, string> headers)
+        string? jsonData,
+        Dictionary<string, string>? headers)
         : base(url, headers)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));
@@ -78,7 +80,7 @@ public sealed class JsonPatchNetworkRequest : NetworkRequest
     /// <summary>
     /// Gets or sets the data.
     /// </summary>
-    public string Data { get; set; }
+    public string? Data { get; set; }
 
     /// <summary>
     /// Executes the network request.
@@ -95,7 +97,7 @@ public sealed class JsonPatchNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
     }
 
     /// <summary>
@@ -115,7 +117,7 @@ public sealed class JsonPatchNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)
@@ -155,6 +157,6 @@ public sealed class JsonPatchNetworkRequest : NetworkRequest
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/MADE.Networking/Http/Requests/Json/JsonPatchNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonPatchNetworkRequest.cs
@@ -97,7 +97,8 @@ public sealed class JsonPatchNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {typeof(TResponse).Name}.");
     }
 
     /// <summary>
@@ -117,7 +118,8 @@ public sealed class JsonPatchNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {expectedResponse.Name}.");
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)
@@ -139,7 +141,7 @@ public sealed class JsonPatchNetworkRequest : NetworkRequest
         {
             Method = new HttpMethod("PATCH"),
             RequestUri = uri,
-            Content = new StringContent(this.Data, Encoding.UTF8, "application/json"),
+            Content = new StringContent(this.Data ?? string.Empty, Encoding.UTF8, "application/json"),
         };
 
         if (this.Headers != null)

--- a/src/MADE.Networking/Http/Requests/Json/JsonPostNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonPostNetworkRequest.cs
@@ -16,6 +16,8 @@ namespace MADE.Networking.Http.Requests.Json;
 /// </summary>
 public sealed class JsonPostNetworkRequest : NetworkRequest
 {
+    private static readonly JsonSerializerOptions DefaultJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
     private readonly HttpClient client;
 
     /// <summary>
@@ -44,7 +46,7 @@ public sealed class JsonPostNetworkRequest : NetworkRequest
     /// <param name="jsonData">
     /// The JSON data to post.
     /// </param>
-    public JsonPostNetworkRequest(HttpClient client, string url, string jsonData)
+    public JsonPostNetworkRequest(HttpClient client, string url, string? jsonData)
         : this(client, url, jsonData, null)
     {
     }
@@ -67,8 +69,8 @@ public sealed class JsonPostNetworkRequest : NetworkRequest
     public JsonPostNetworkRequest(
         HttpClient client,
         string url,
-        string jsonData,
-        Dictionary<string, string> headers)
+        string? jsonData,
+        Dictionary<string, string>? headers)
         : base(url, headers)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));
@@ -78,7 +80,7 @@ public sealed class JsonPostNetworkRequest : NetworkRequest
     /// <summary>
     /// Gets or sets the data.
     /// </summary>
-    public string Data { get; set; }
+    public string? Data { get; set; }
 
     /// <summary>
     /// Executes the network request.
@@ -95,7 +97,7 @@ public sealed class JsonPostNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
     }
 
     /// <summary>
@@ -115,7 +117,7 @@ public sealed class JsonPostNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)
@@ -153,6 +155,6 @@ public sealed class JsonPostNetworkRequest : NetworkRequest
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/MADE.Networking/Http/Requests/Json/JsonPostNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonPostNetworkRequest.cs
@@ -97,7 +97,8 @@ public sealed class JsonPostNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {typeof(TResponse).Name}.");
     }
 
     /// <summary>
@@ -117,7 +118,8 @@ public sealed class JsonPostNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {expectedResponse.Name}.");
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)
@@ -137,7 +139,7 @@ public sealed class JsonPostNetworkRequest : NetworkRequest
 
         using var request = new HttpRequestMessage(HttpMethod.Post, uri)
         {
-            Content = new StringContent(this.Data, Encoding.UTF8, "application/json"),
+            Content = new StringContent(this.Data ?? string.Empty, Encoding.UTF8, "application/json"),
         };
 
         if (this.Headers != null)

--- a/src/MADE.Networking/Http/Requests/Json/JsonPutNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonPutNetworkRequest.cs
@@ -16,6 +16,8 @@ namespace MADE.Networking.Http.Requests.Json;
 /// </summary>
 public sealed class JsonPutNetworkRequest : NetworkRequest
 {
+    private static readonly JsonSerializerOptions DefaultJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
     private readonly HttpClient client;
 
     /// <summary>
@@ -44,7 +46,7 @@ public sealed class JsonPutNetworkRequest : NetworkRequest
     /// <param name="jsonData">
     /// The JSON data to put.
     /// </param>
-    public JsonPutNetworkRequest(HttpClient client, string url, string jsonData)
+    public JsonPutNetworkRequest(HttpClient client, string url, string? jsonData)
         : this(client, url, jsonData, null)
     {
     }
@@ -64,7 +66,7 @@ public sealed class JsonPutNetworkRequest : NetworkRequest
     /// <param name="headers">
     /// The additional headers.
     /// </param>
-    public JsonPutNetworkRequest(HttpClient client, string url, string jsonData, Dictionary<string, string> headers)
+    public JsonPutNetworkRequest(HttpClient client, string url, string? jsonData, Dictionary<string, string>? headers)
         : base(url, headers)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));
@@ -74,7 +76,7 @@ public sealed class JsonPutNetworkRequest : NetworkRequest
     /// <summary>
     /// Gets or sets the data.
     /// </summary>
-    public string Data { get; set; }
+    public string? Data { get; set; }
 
     /// <summary>
     /// Executes the network request.
@@ -91,7 +93,7 @@ public sealed class JsonPutNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
     }
 
     /// <summary>
@@ -111,7 +113,7 @@ public sealed class JsonPutNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)
@@ -149,6 +151,6 @@ public sealed class JsonPutNetworkRequest : NetworkRequest
 
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/MADE.Networking/Http/Requests/Json/JsonPutNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Json/JsonPutNetworkRequest.cs
@@ -93,7 +93,8 @@ public sealed class JsonPutNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {typeof(TResponse).Name}.");
     }
 
     /// <summary>
@@ -113,7 +114,8 @@ public sealed class JsonPutNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.GetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response to {expectedResponse.Name}.");
     }
 
     private async Task<string> GetJsonResponseAsync(CancellationToken cancellationToken = default)
@@ -133,7 +135,7 @@ public sealed class JsonPutNetworkRequest : NetworkRequest
 
         using var request = new HttpRequestMessage(HttpMethod.Put, uri)
         {
-            Content = new StringContent(this.Data, Encoding.UTF8, "application/json"),
+            Content = new StringContent(this.Data ?? string.Empty, Encoding.UTF8, "application/json"),
         };
 
         if (this.Headers != null)

--- a/src/MADE.Networking/Http/Requests/MultipartFormDataPostNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/MultipartFormDataPostNetworkRequest.cs
@@ -11,6 +11,8 @@ namespace MADE.Networking.Http.Requests;
 /// </summary>
 public sealed class MultipartFormDataPostNetworkRequest : NetworkRequest
 {
+    private static readonly JsonSerializerOptions DefaultJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
     private readonly HttpClient client;
 
     /// <summary>
@@ -32,7 +34,7 @@ public sealed class MultipartFormDataPostNetworkRequest : NetworkRequest
     public MultipartFormDataPostNetworkRequest(
         HttpClient client,
         string url,
-        Dictionary<string, string> headers)
+        Dictionary<string, string>? headers)
         : base(url, headers)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));
@@ -100,7 +102,7 @@ public sealed class MultipartFormDataPostNetworkRequest : NetworkRequest
     public override async Task<TResponse> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
     {
         string json = await this.PostAndGetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<TResponse>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize<TResponse>(json, DefaultJsonOptions);
     }
 
     /// <inheritdoc/>
@@ -109,7 +111,7 @@ public sealed class MultipartFormDataPostNetworkRequest : NetworkRequest
         CancellationToken cancellationToken = default)
     {
         string json = await this.PostAndGetJsonResponseAsync(cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize(json, expectedResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize(json, expectedResponse, DefaultJsonOptions);
     }
 
     private async Task<string> PostAndGetJsonResponseAsync(CancellationToken cancellationToken = default)

--- a/src/MADE.Networking/Http/Requests/NetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/NetworkRequest.cs
@@ -33,7 +33,7 @@ public abstract class NetworkRequest : INetworkRequest
     /// <param name="headers">
     /// Additional headers for the request.
     /// </param>
-    protected NetworkRequest(string url, Dictionary<string, string> headers)
+    protected NetworkRequest(string url, Dictionary<string, string>? headers)
     {
         this.Identifier = Guid.NewGuid();
         this.Url = url;

--- a/src/MADE.Networking/Http/Requests/NetworkRequestCallback.cs
+++ b/src/MADE.Networking/Http/Requests/NetworkRequestCallback.cs
@@ -31,7 +31,7 @@ public sealed class NetworkRequestCallback
     /// <param name="successCallback">
     /// The success callback.
     /// </param>
-    public NetworkRequestCallback(NetworkRequest request, WeakReferenceCallback successCallback)
+    public NetworkRequestCallback(NetworkRequest request, WeakReferenceCallback? successCallback)
         : this(request, successCallback, null)
     {
     }
@@ -50,8 +50,8 @@ public sealed class NetworkRequestCallback
     /// </param>
     public NetworkRequestCallback(
         NetworkRequest request,
-        WeakReferenceCallback successCallback,
-        WeakReferenceCallback errorCallback)
+        WeakReferenceCallback? successCallback,
+        WeakReferenceCallback? errorCallback)
     {
         this.Request = request ?? throw new ArgumentNullException(nameof(request));
         this.SuccessCallback = successCallback;
@@ -66,10 +66,10 @@ public sealed class NetworkRequestCallback
     /// <summary>
     /// Gets the success callback.
     /// </summary>
-    public WeakReferenceCallback SuccessCallback { get; }
+    public WeakReferenceCallback? SuccessCallback { get; }
 
     /// <summary>
     /// Gets the error callback.
     /// </summary>
-    public WeakReferenceCallback ErrorCallback { get; }
+    public WeakReferenceCallback? ErrorCallback { get; }
 }

--- a/src/MADE.Networking/Http/Requests/Streams/StreamGetNetworkRequest.cs
+++ b/src/MADE.Networking/Http/Requests/Streams/StreamGetNetworkRequest.cs
@@ -43,7 +43,7 @@ public sealed class StreamGetNetworkRequest : NetworkRequest
     /// <param name="headers">
     /// The additional headers.
     /// </param>
-    public StreamGetNetworkRequest(HttpClient client, string url, Dictionary<string, string> headers)
+    public StreamGetNetworkRequest(HttpClient client, string url, Dictionary<string, string>? headers)
         : base(url, headers)
     {
         this.client = client ?? throw new ArgumentNullException(nameof(client));

--- a/src/MADE.Networking/Http/Responses/HttpResponseMessage{T}.cs
+++ b/src/MADE.Networking/Http/Responses/HttpResponseMessage{T}.cs
@@ -48,12 +48,12 @@ public class HttpResponseMessage<T> : IDisposable
     /// <summary>
     /// Gets the reason phrase that typically is sent by servers together with the status code.
     /// </summary>
-    public string ReasonPhrase => this.response.ReasonPhrase;
+    public string? ReasonPhrase => this.response.ReasonPhrase;
 
     /// <summary>
     /// Gets the request message which led to this response message.
     /// </summary>
-    public HttpRequestMessage RequestMessage => this.response.RequestMessage;
+    public HttpRequestMessage? RequestMessage => this.response.RequestMessage;
 
     /// <summary>
     /// Gets the status code of the HTTP response.
@@ -71,7 +71,7 @@ public class HttpResponseMessage<T> : IDisposable
     /// Note, ensure that <see cref="DeserializeAsync"/> has been called first, otherwise this value will be default.
     /// </para>
     /// </summary>
-    public T DeserializedContent { get; private set; }
+    public T? DeserializedContent { get; private set; }
 
     /// <summary>
     /// Allows conversion of a <see cref="HttpResponseMessage"/> to the <see cref="HttpResponseMessage{T}"/> without direct casting.

--- a/src/MADE.Networking/MADE.Networking.csproj
+++ b/src/MADE.Networking/MADE.Networking.csproj
@@ -8,7 +8,6 @@
       A perfect companion to any application handling networking.
     </Description>
     <PackageTags>MADE Networking Extensions Json Stream HttpClient</PackageTags>
-    <NoWarn>$(NoWarn);CS8600;CS8601;CS8603;CS8604;CS8618;CS8622;CS8625;CA1001;CA1869;CA2016</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MADE.Threading/Timer.cs
+++ b/src/MADE.Threading/Timer.cs
@@ -64,12 +64,14 @@ public class Timer : ITimer, IDisposable
     /// </param>
     public void Start(TimeSpan dueTime)
     {
+        this.DueTime = dueTime;
+
         if (this.timer == null)
         {
             this.timer = new System.Threading.Timer(
                 c => this.InvokeTick(),
                 null,
-                dueTime.Milliseconds,
+                (int)Math.Ceiling(dueTime.TotalMilliseconds),
                 (int)Math.Ceiling(this.Interval.TotalMilliseconds));
         }
         else
@@ -90,6 +92,8 @@ public class Timer : ITimer, IDisposable
     /// </param>
     public void Start(int dueTime)
     {
+        this.DueTime = TimeSpan.FromMilliseconds(dueTime);
+
         if (this.timer == null)
         {
             this.timer = new System.Threading.Timer(
@@ -101,7 +105,7 @@ public class Timer : ITimer, IDisposable
         else
         {
             this.timer.Change(
-                (int)Math.Ceiling(this.DueTime.TotalMilliseconds),
+                dueTime,
                 (int)Math.Ceiling(this.Interval.TotalMilliseconds));
         }
 

--- a/tests/MADE.Foundation.Tests/MADE.Foundation.Tests.csproj
+++ b/tests/MADE.Foundation.Tests/MADE.Foundation.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MADE.Foundation\MADE.Foundation.csproj" />
+    <ProjectReference Include="..\..\src\MADE.Testing\MADE.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MADE.Foundation.Tests/Tests/PlatformApiHelperTests.cs
+++ b/tests/MADE.Foundation.Tests/Tests/PlatformApiHelperTests.cs
@@ -1,0 +1,167 @@
+using System.Diagnostics.CodeAnalysis;
+using MADE.Foundation.Platform;
+using NUnit.Framework;
+using Shouldly;
+
+namespace MADE.Foundation.Tests.Tests;
+
+[ExcludeFromCodeCoverage]
+[TestFixture]
+public class PlatformApiHelperTests
+{
+    public class WhenCheckingTypeSupport
+    {
+        [Test]
+        public void ShouldReturnTrueForTypeWithoutPlatformNotSupportedAttribute()
+        {
+            // Arrange & Act
+            bool result = PlatformApiHelper.IsTypeSupported(typeof(SupportedType));
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ShouldReturnFalseForTypeWithPlatformNotSupportedAttribute()
+        {
+            // Arrange & Act
+            bool result = PlatformApiHelper.IsTypeSupported(typeof(UnsupportedType));
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Test]
+        public void ShouldCacheResultForSameType()
+        {
+            // Arrange & Act
+            bool first = PlatformApiHelper.IsTypeSupported(typeof(SupportedType));
+            bool second = PlatformApiHelper.IsTypeSupported(typeof(SupportedType));
+
+            // Assert
+            first.ShouldBeTrue();
+            second.ShouldBeTrue();
+        }
+    }
+
+    public class WhenCheckingMethodSupport
+    {
+        [Test]
+        public void ShouldReturnTrueForSupportedTypeRegardlessOfMethod()
+        {
+            // Arrange & Act - when the type is supported, all methods are considered supported
+            bool result = PlatformApiHelper.IsMethodSupported(typeof(MixedSupportType), nameof(MixedSupportType.SupportedMethod));
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ShouldReturnTrueForSupportedTypeEvenWithUnsupportedMethodAttribute()
+        {
+            // Arrange & Act - type-level support takes precedence
+            bool result = PlatformApiHelper.IsMethodSupported(typeof(MixedSupportType), nameof(MixedSupportType.UnsupportedMethod));
+
+            // Assert - type is supported, so the result is true
+            result.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ShouldReturnTrueForUnsupportedTypeWithSupportedMethod()
+        {
+            // Arrange & Act - type is unsupported, but the individual method does not have the attribute
+            bool result = PlatformApiHelper.IsMethodSupported(typeof(UnsupportedType), nameof(UnsupportedType.SomeMethod));
+
+            // Assert - the method itself is supported even though the type is not
+            result.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ShouldReturnFalseForUnsupportedTypeWithUnsupportedMethod()
+        {
+            // Arrange & Act
+            bool result = PlatformApiHelper.IsMethodSupported(typeof(UnsupportedTypeWithUnsupportedMethod), nameof(UnsupportedTypeWithUnsupportedMethod.AlsoUnsupported));
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+    }
+
+    public class WhenCheckingPropertySupport
+    {
+        [Test]
+        public void ShouldReturnTrueForSupportedTypeProperty()
+        {
+            // Arrange & Act
+            bool result = PlatformApiHelper.IsPropertySupported(typeof(MixedSupportType), nameof(MixedSupportType.SupportedProperty));
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ShouldReturnTrueForSupportedTypeEvenWithUnsupportedPropertyAttribute()
+        {
+            // Arrange & Act - type-level support takes precedence
+            bool result = PlatformApiHelper.IsPropertySupported(typeof(MixedSupportType), nameof(MixedSupportType.UnsupportedProperty));
+
+            // Assert - type is supported, so result is true
+            result.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ShouldReturnFalseForUnsupportedTypeWithUnsupportedProperty()
+        {
+            // Arrange & Act
+            bool result = PlatformApiHelper.IsPropertySupported(typeof(UnsupportedTypeWithUnsupportedProp), nameof(UnsupportedTypeWithUnsupportedProp.AlsoUnsupported));
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+    }
+}
+
+public class SupportedType
+{
+}
+
+[PlatformNotSupported]
+public class UnsupportedType
+{
+    public void SomeMethod()
+    {
+    }
+}
+
+[PlatformNotSupported]
+public class UnsupportedTypeWithUnsupportedMethod
+{
+    [PlatformNotSupported]
+    public void AlsoUnsupported()
+    {
+    }
+}
+
+[PlatformNotSupported]
+public class UnsupportedTypeWithUnsupportedProp
+{
+    [PlatformNotSupported]
+    public string? AlsoUnsupported { get; set; }
+}
+
+public class MixedSupportType
+{
+    public string? SupportedProperty { get; set; }
+
+    [PlatformNotSupported]
+    public string? UnsupportedProperty { get; set; }
+
+    public void SupportedMethod()
+    {
+    }
+
+    [PlatformNotSupported]
+    public void UnsupportedMethod()
+    {
+    }
+}

--- a/tests/MADE.Foundation.Tests/Tests/PlatformApiHelperTests.cs
+++ b/tests/MADE.Foundation.Tests/Tests/PlatformApiHelperTests.cs
@@ -119,49 +119,49 @@ public class PlatformApiHelperTests
             result.ShouldBeFalse();
         }
     }
-}
 
-public class SupportedType
-{
-}
-
-[PlatformNotSupported]
-public class UnsupportedType
-{
-    public void SomeMethod()
-    {
-    }
-}
-
-[PlatformNotSupported]
-public class UnsupportedTypeWithUnsupportedMethod
-{
-    [PlatformNotSupported]
-    public void AlsoUnsupported()
-    {
-    }
-}
-
-[PlatformNotSupported]
-public class UnsupportedTypeWithUnsupportedProp
-{
-    [PlatformNotSupported]
-    public string? AlsoUnsupported { get; set; }
-}
-
-public class MixedSupportType
-{
-    public string? SupportedProperty { get; set; }
-
-    [PlatformNotSupported]
-    public string? UnsupportedProperty { get; set; }
-
-    public void SupportedMethod()
+    private class SupportedType
     {
     }
 
     [PlatformNotSupported]
-    public void UnsupportedMethod()
+    private class UnsupportedType
     {
+        public void SomeMethod()
+        {
+        }
+    }
+
+    [PlatformNotSupported]
+    private class UnsupportedTypeWithUnsupportedMethod
+    {
+        [PlatformNotSupported]
+        public void AlsoUnsupported()
+        {
+        }
+    }
+
+    [PlatformNotSupported]
+    private class UnsupportedTypeWithUnsupportedProp
+    {
+        [PlatformNotSupported]
+        public string? AlsoUnsupported { get; set; }
+    }
+
+    private class MixedSupportType
+    {
+        public string? SupportedProperty { get; set; }
+
+        [PlatformNotSupported]
+        public string? UnsupportedProperty { get; set; }
+
+        public void SupportedMethod()
+        {
+        }
+
+        [PlatformNotSupported]
+        public void UnsupportedMethod()
+        {
+        }
     }
 }

--- a/tests/MADE.Foundation.Tests/Tests/PlatformNotSupportedAttributeTests.cs
+++ b/tests/MADE.Foundation.Tests/Tests/PlatformNotSupportedAttributeTests.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics.CodeAnalysis;
+using MADE.Foundation.Platform;
+using NUnit.Framework;
+using Shouldly;
+
+namespace MADE.Foundation.Tests.Tests;
+
+[ExcludeFromCodeCoverage]
+[TestFixture]
+public class PlatformNotSupportedAttributeTests
+{
+    [Test]
+    public void ShouldBeApplicableToAllTargets()
+    {
+        // Arrange
+        var attribute = typeof(PlatformNotSupportedAttribute)
+            .GetCustomAttributes(typeof(AttributeUsageAttribute), false)
+            .Cast<AttributeUsageAttribute>()
+            .Single();
+
+        // Assert
+        attribute.ValidOn.ShouldBe(AttributeTargets.All);
+        attribute.Inherited.ShouldBeFalse();
+    }
+
+    [Test]
+    public void ShouldBeConstructable()
+    {
+        // Arrange & Act
+        var attribute = new PlatformNotSupportedAttribute();
+
+        // Assert
+        attribute.ShouldNotBeNull();
+    }
+}

--- a/tests/MADE.Foundation.Tests/Tests/PlatformNotSupportedExceptionTests.cs
+++ b/tests/MADE.Foundation.Tests/Tests/PlatformNotSupportedExceptionTests.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+using Shouldly;
+
+using PlatformNotSupportedException = MADE.Foundation.Platform.PlatformNotSupportedException;
+
+namespace MADE.Foundation.Tests.Tests;
+
+[ExcludeFromCodeCoverage]
+[TestFixture]
+public class PlatformNotSupportedExceptionTests
+{
+    [Test]
+    public void ShouldConstructWithDefaultMessage()
+    {
+        // Arrange & Act
+        var exception = new PlatformNotSupportedException();
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.ShouldBeOfType<PlatformNotSupportedException>();
+        exception.ShouldBeAssignableTo<NotImplementedException>();
+    }
+
+    [Test]
+    public void ShouldConstructWithMessage()
+    {
+        // Arrange
+        const string message = "This API is not supported on this platform.";
+
+        // Act
+        var exception = new PlatformNotSupportedException(message);
+
+        // Assert
+        exception.Message.ShouldBe(message);
+    }
+
+    [Test]
+    public void ShouldConstructWithMessageAndInnerException()
+    {
+        // Arrange
+        const string message = "This API is not supported on this platform.";
+        var inner = new InvalidOperationException("Inner error");
+
+        // Act
+        var exception = new PlatformNotSupportedException(message, inner);
+
+        // Assert
+        exception.Message.ShouldBe(message);
+        exception.InnerException.ShouldBe(inner);
+    }
+}

--- a/tests/MADE.Runtime.Tests/MADE.Runtime.Tests.csproj
+++ b/tests/MADE.Runtime.Tests/MADE.Runtime.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MADE.Runtime\MADE.Runtime.csproj" />
+    <ProjectReference Include="..\..\src\MADE.Testing\MADE.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MADE.Runtime.Tests/Tests/WeakReferenceCallbackTests.cs
+++ b/tests/MADE.Runtime.Tests/Tests/WeakReferenceCallbackTests.cs
@@ -59,10 +59,8 @@ public class WeakReferenceCallbackTests
             GC.Collect();
 
             // Act & Assert
-            if (!callback.IsAlive)
-            {
-                Should.Throw<InvalidOperationException>(() => callback.Invoke("test"));
-            }
+            Assume.That(callback.IsAlive, Is.False, "Callback target is still alive; cannot assert dead-target behavior deterministically.");
+            Should.Throw<InvalidOperationException>(() => callback.Invoke("test"));
         }
     }
 

--- a/tests/MADE.Runtime.Tests/Tests/WeakReferenceCallbackTests.cs
+++ b/tests/MADE.Runtime.Tests/Tests/WeakReferenceCallbackTests.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics.CodeAnalysis;
+using MADE.Runtime;
+using NUnit.Framework;
+using Shouldly;
+
+namespace MADE.Runtime.Tests.Tests;
+
+[ExcludeFromCodeCoverage]
+[TestFixture]
+public class WeakReferenceCallbackTests
+{
+    public class WhenInvokingCallback
+    {
+        [Test]
+        public void ShouldInvokeCallbackWithParameter()
+        {
+            // Arrange
+            string? capturedValue = null;
+            Action<string> action = s => capturedValue = s;
+            var callback = new WeakReferenceCallback(action, typeof(string));
+
+            // Act
+            callback.Invoke("Hello");
+
+            // Assert
+            capturedValue.ShouldBe("Hello");
+        }
+
+        [Test]
+        public void ShouldReportIsAliveWhenTargetExists()
+        {
+            // Arrange
+            var target = new CallbackTarget();
+            Action<string> action = target.Handle;
+            var callback = new WeakReferenceCallback(action, typeof(string));
+
+            // Act & Assert
+            callback.IsAlive.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ShouldStoreExpectedType()
+        {
+            // Arrange
+            Action<int> action = _ => { };
+            var callback = new WeakReferenceCallback(action, typeof(int));
+
+            // Act & Assert
+            callback.Type.ShouldBe(typeof(int));
+        }
+
+        [Test]
+        public void ShouldThrowWhenCallbackIsNoLongerAlive()
+        {
+            // Arrange
+            var callback = CreateCallbackWithWeakTarget();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            // Act & Assert
+            if (!callback.IsAlive)
+            {
+                Should.Throw<InvalidOperationException>(() => callback.Invoke("test"));
+            }
+        }
+    }
+
+    private static WeakReferenceCallback CreateCallbackWithWeakTarget()
+    {
+        var target = new CallbackTarget();
+        Action<string> action = target.Handle;
+        return new WeakReferenceCallback(action, typeof(string));
+    }
+
+    private class CallbackTarget
+    {
+        public string? LastValue { get; private set; }
+
+        public void Handle(string value)
+        {
+            this.LastValue = value;
+        }
+    }
+}

--- a/tests/MADE.Runtime.Tests/Tests/WeakReferenceEventListenerTests.cs
+++ b/tests/MADE.Runtime.Tests/Tests/WeakReferenceEventListenerTests.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics.CodeAnalysis;
+using MADE.Runtime;
+using NUnit.Framework;
+using Shouldly;
+
+namespace MADE.Runtime.Tests.Tests;
+
+[ExcludeFromCodeCoverage]
+[TestFixture]
+public class WeakReferenceEventListenerTests
+{
+    public class WhenEventFires
+    {
+        [Test]
+        public void ShouldInvokeOnEventActionWhenInstanceIsAlive()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, string>(instance);
+
+            string? capturedSource = null;
+            listener.OnEventAction = (inst, src) => capturedSource = src;
+
+            // Act
+            listener.OnEvent("SourceData");
+
+            // Assert
+            capturedSource.ShouldBe("SourceData");
+        }
+
+        [Test]
+        public void ShouldNotThrowWhenOnEventActionIsNull()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, string>(instance);
+
+            // Act & Assert
+            Should.NotThrow(() => listener.OnEvent("SourceData"));
+        }
+    }
+
+    public class WhenDetaching
+    {
+        [Test]
+        public void ShouldInvokeOnDetachAction()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, string>(instance);
+
+            bool detachCalled = false;
+            listener.OnDetachAction = (inst, lst) => detachCalled = true;
+
+            // Act
+            listener.Detach();
+
+            // Assert
+            detachCalled.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ShouldClearOnDetachActionAfterDetach()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, string>(instance);
+
+            int detachCount = 0;
+            listener.OnDetachAction = (inst, lst) => detachCount++;
+
+            // Act
+            listener.Detach();
+            listener.Detach();
+
+            // Assert
+            detachCount.ShouldBe(1);
+        }
+
+        [Test]
+        public void ShouldNotThrowWhenOnDetachActionIsNull()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, string>(instance);
+
+            // Act & Assert
+            Should.NotThrow(() => listener.Detach());
+        }
+    }
+
+    public class WhenConstructing
+    {
+        [Test]
+        public void ShouldThrowWhenInstanceIsNull()
+        {
+            // Act & Assert
+            Should.Throw<ArgumentNullException>(
+                () => new WeakReferenceEventListener<ListenerInstance, string>(null!));
+        }
+    }
+
+    private class ListenerInstance
+    {
+    }
+}

--- a/tests/MADE.Runtime.Tests/Tests/WeakReferenceEventListenerWithEventArgsTests.cs
+++ b/tests/MADE.Runtime.Tests/Tests/WeakReferenceEventListenerWithEventArgsTests.cs
@@ -43,19 +43,15 @@ public class WeakReferenceEventListenerWithEventArgsTests
         public void ShouldDetachWhenInstanceIsCollected()
         {
             // Arrange
-            bool detached = false;
             var listener = CreateListenerWithWeakInstance(out _);
-            listener.OnDetachAction = (_, _) => detached = true;
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            // Act
-            listener.OnEvent(new object(), "EventData");
-
-            // Assert - if GC collected the instance, it should have called Detach
-            // Note: GC behavior is non-deterministic, so we just verify no exception is thrown
+            // Act & Assert - GC behavior is non-deterministic, so verify the listener
+            // safely handles event dispatch even when the weak target may no longer be alive.
+            Should.NotThrow(() => listener.OnEvent(new object(), "EventData"));
         }
     }
 

--- a/tests/MADE.Runtime.Tests/Tests/WeakReferenceEventListenerWithEventArgsTests.cs
+++ b/tests/MADE.Runtime.Tests/Tests/WeakReferenceEventListenerWithEventArgsTests.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics.CodeAnalysis;
+using MADE.Runtime;
+using NUnit.Framework;
+using Shouldly;
+
+namespace MADE.Runtime.Tests.Tests;
+
+[ExcludeFromCodeCoverage]
+[TestFixture]
+public class WeakReferenceEventListenerWithEventArgsTests
+{
+    public class WhenEventFires
+    {
+        [Test]
+        public void ShouldInvokeOnEventActionWhenInstanceIsAlive()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, object, string>(instance);
+
+            string? capturedArg = null;
+            listener.OnEventAction = (inst, src, args) => capturedArg = args;
+
+            // Act
+            listener.OnEvent(new object(), "EventData");
+
+            // Assert
+            capturedArg.ShouldBe("EventData");
+        }
+
+        [Test]
+        public void ShouldNotThrowWhenOnEventActionIsNull()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, object, string>(instance);
+
+            // Act & Assert
+            Should.NotThrow(() => listener.OnEvent(new object(), "EventData"));
+        }
+
+        [Test]
+        public void ShouldDetachWhenInstanceIsCollected()
+        {
+            // Arrange
+            bool detached = false;
+            var listener = CreateListenerWithWeakInstance(out _);
+            listener.OnDetachAction = (_, _) => detached = true;
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            // Act
+            listener.OnEvent(new object(), "EventData");
+
+            // Assert - if GC collected the instance, it should have called Detach
+            // Note: GC behavior is non-deterministic, so we just verify no exception is thrown
+        }
+    }
+
+    public class WhenDetaching
+    {
+        [Test]
+        public void ShouldInvokeOnDetachAction()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, object, string>(instance);
+
+            bool detachCalled = false;
+            listener.OnDetachAction = (inst, lst) => detachCalled = true;
+
+            // Act
+            listener.Detach();
+
+            // Assert
+            detachCalled.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ShouldClearOnDetachActionAfterDetach()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, object, string>(instance);
+
+            int detachCount = 0;
+            listener.OnDetachAction = (inst, lst) => detachCount++;
+
+            // Act
+            listener.Detach();
+            listener.Detach(); // Second call should be a no-op
+
+            // Assert
+            detachCount.ShouldBe(1);
+        }
+
+        [Test]
+        public void ShouldNotThrowWhenOnDetachActionIsNull()
+        {
+            // Arrange
+            var instance = new ListenerInstance();
+            var listener = new WeakReferenceEventListener<ListenerInstance, object, string>(instance);
+
+            // Act & Assert
+            Should.NotThrow(() => listener.Detach());
+        }
+    }
+
+    public class WhenConstructing
+    {
+        [Test]
+        public void ShouldThrowWhenInstanceIsNull()
+        {
+            // Act & Assert
+            Should.Throw<ArgumentNullException>(
+                () => new WeakReferenceEventListener<ListenerInstance, object, string>(null!));
+        }
+    }
+
+    private static WeakReferenceEventListener<ListenerInstance, object, string> CreateListenerWithWeakInstance(
+        out WeakReference<ListenerInstance> weakRef)
+    {
+        var instance = new ListenerInstance();
+        weakRef = new WeakReference<ListenerInstance>(instance);
+        return new WeakReferenceEventListener<ListenerInstance, object, string>(instance);
+    }
+
+    private class ListenerInstance
+    {
+    }
+}

--- a/tests/MADE.Threading.Tests/Tests/TimerTests.cs
+++ b/tests/MADE.Threading.Tests/Tests/TimerTests.cs
@@ -1,0 +1,211 @@
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+using Shouldly;
+
+namespace MADE.Threading.Tests.Tests;
+
+[ExcludeFromCodeCoverage]
+[TestFixture]
+public class TimerTests
+{
+    public class WhenStarting
+    {
+        [Test]
+        public async Task ShouldSetIsRunningToTrue()
+        {
+            // Arrange
+            using var timer = new Timer { Interval = TimeSpan.FromMilliseconds(500) };
+
+            // Act
+            timer.Start();
+
+            // Assert
+            timer.IsRunning.ShouldBeTrue();
+
+            await Task.Delay(50);
+        }
+
+        [Test]
+        public async Task ShouldTickAtInterval()
+        {
+            // Arrange
+            using var timer = new Timer { Interval = TimeSpan.FromMilliseconds(50) };
+            int tickCount = 0;
+            timer.Tick += (_, _) => Interlocked.Increment(ref tickCount);
+
+            // Act
+            timer.Start();
+            await Task.Delay(200);
+            timer.Stop();
+
+            // Assert
+            tickCount.ShouldBeGreaterThan(0);
+        }
+    }
+
+    public class WhenStartingWithTimeSpanDueTime
+    {
+        [Test]
+        public async Task ShouldStoreDueTimeProperty()
+        {
+            // Arrange
+            using var timer = new Timer { Interval = TimeSpan.FromMilliseconds(500) };
+            var dueTime = TimeSpan.FromMilliseconds(100);
+
+            // Act
+            timer.Start(dueTime);
+
+            // Assert
+            timer.DueTime.ShouldBe(dueTime);
+            timer.IsRunning.ShouldBeTrue();
+
+            await Task.Delay(50);
+        }
+
+        [Test]
+        public async Task ShouldDelayFirstTickByDueTime()
+        {
+            // Arrange
+            using var timer = new Timer { Interval = TimeSpan.FromMilliseconds(500) };
+            int tickCount = 0;
+            timer.Tick += (_, _) => Interlocked.Increment(ref tickCount);
+
+            // Act
+            timer.Start(TimeSpan.FromMilliseconds(150));
+            await Task.Delay(50);
+
+            // Assert - should not have ticked yet
+            tickCount.ShouldBe(0);
+
+            // Wait for the due time to pass
+            await Task.Delay(200);
+            tickCount.ShouldBeGreaterThan(0);
+        }
+    }
+
+    public class WhenStartingWithIntDueTime
+    {
+        [Test]
+        public async Task ShouldStoreDueTimeProperty()
+        {
+            // Arrange
+            using var timer = new Timer { Interval = TimeSpan.FromMilliseconds(500) };
+
+            // Act
+            timer.Start(100);
+
+            // Assert
+            timer.DueTime.ShouldBe(TimeSpan.FromMilliseconds(100));
+            timer.IsRunning.ShouldBeTrue();
+
+            await Task.Delay(50);
+        }
+
+        [Test]
+        public async Task ShouldDelayFirstTickByDueTime()
+        {
+            // Arrange
+            using var timer = new Timer { Interval = TimeSpan.FromMilliseconds(500) };
+            int tickCount = 0;
+            timer.Tick += (_, _) => Interlocked.Increment(ref tickCount);
+
+            // Act
+            timer.Start(150);
+            await Task.Delay(50);
+
+            // Assert - should not have ticked yet
+            tickCount.ShouldBe(0);
+
+            // Wait for the due time to pass
+            await Task.Delay(200);
+            tickCount.ShouldBeGreaterThan(0);
+        }
+
+        [Test]
+        public async Task ShouldUseDueTimeOnRestart()
+        {
+            // Arrange
+            using var timer = new Timer { Interval = TimeSpan.FromMilliseconds(500) };
+            int tickCount = 0;
+            timer.Tick += (_, _) => Interlocked.Increment(ref tickCount);
+
+            // Act - start once to create internal timer, stop, then restart with int dueTime
+            timer.Start();
+            await Task.Delay(50);
+            timer.Stop();
+
+            tickCount = 0;
+            timer.Start(200);
+            await Task.Delay(50);
+
+            // Assert - should not have ticked yet (dueTime not elapsed)
+            tickCount.ShouldBe(0);
+
+            await Task.Delay(250);
+            tickCount.ShouldBeGreaterThan(0);
+        }
+    }
+
+    public class WhenStopping
+    {
+        [Test]
+        public async Task ShouldSetIsRunningToFalse()
+        {
+            // Arrange
+            using var timer = new Timer { Interval = TimeSpan.FromMilliseconds(500) };
+            timer.Start();
+
+            // Act
+            timer.Stop();
+
+            // Assert
+            timer.IsRunning.ShouldBeFalse();
+
+            await Task.Delay(50);
+        }
+
+        [Test]
+        public async Task ShouldStopTicking()
+        {
+            // Arrange
+            using var timer = new Timer { Interval = TimeSpan.FromMilliseconds(50) };
+            int tickCount = 0;
+            timer.Tick += (_, _) => Interlocked.Increment(ref tickCount);
+
+            timer.Start();
+            await Task.Delay(150);
+            timer.Stop();
+
+            int ticksAfterStop = tickCount;
+            await Task.Delay(150);
+
+            // Assert - no additional ticks after stopping
+            tickCount.ShouldBe(ticksAfterStop);
+        }
+    }
+
+    public class WhenDisposing
+    {
+        [Test]
+        public void ShouldNotThrowWhenDisposedWithoutStarting()
+        {
+            // Arrange
+            var timer = new Timer();
+
+            // Act & Assert
+            Should.NotThrow(() => timer.Dispose());
+        }
+
+        [Test]
+        public async Task ShouldNotThrowWhenDisposedAfterStarting()
+        {
+            // Arrange
+            var timer = new Timer { Interval = TimeSpan.FromMilliseconds(50) };
+            timer.Start();
+            await Task.Delay(100);
+
+            // Act & Assert
+            Should.NotThrow(() => timer.Dispose());
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the networking and diagnostics components, as well as updates to the solution file. The most significant changes include making network request APIs more robust and nullable-friendly, improving exception handling to prevent process crashes, and modernizing asynchronous processing in the network request manager.

**Networking API improvements:**

* Updated all network request constructors and methods (e.g., `JsonGetNetworkRequest`, `JsonPostNetworkRequest`, `JsonPatchNetworkRequest`, `JsonDeleteNetworkRequest`) to accept nullable headers and data parameters, improving null-safety and flexibility. [[1]](diffhunk://#diff-f99cd6edba052e3e7e86c21ebfbf0a18a86b2f7586f8cf510aff91d28b950377L36-R72) [[2]](diffhunk://#diff-8939d359eba884fec459ce0cfdc5cf4cbba971cad926b131ed8bbf85114ed566L46-R48) [[3]](diffhunk://#diff-0c45248a057fbe69961cd03736691e390857227adb733602ea3eb8e9a37bdfdbL47-R49) [[4]](diffhunk://#diff-0c45248a057fbe69961cd03736691e390857227adb733602ea3eb8e9a37bdfdbL70-R73) [[5]](diffhunk://#diff-1c786100719dcee71edb7e980679922ff1753519edfffbd9ca33a7c874d72cd4L46-R48) [[6]](diffhunk://#diff-0c45248a057fbe69961cd03736691e390857227adb733602ea3eb8e9a37bdfdbL81-R83)
* Standardized JSON deserialization by introducing a shared `DefaultJsonOptions` instance with case-insensitive property names in all JSON network requests. [[1]](diffhunk://#diff-8939d359eba884fec459ce0cfdc5cf4cbba971cad926b131ed8bbf85114ed566R18-R19) [[2]](diffhunk://#diff-1c786100719dcee71edb7e980679922ff1753519edfffbd9ca33a7c874d72cd4R18-R19) [[3]](diffhunk://#diff-0c45248a057fbe69961cd03736691e390857227adb733602ea3eb8e9a37bdfdbR19-R20) [[4]](diffhunk://#diff-8939d359eba884fec459ce0cfdc5cf4cbba971cad926b131ed8bbf85114ed566L67-R69) [[5]](diffhunk://#diff-8939d359eba884fec459ce0cfdc5cf4cbba971cad926b131ed8bbf85114ed566L87-R89) [[6]](diffhunk://#diff-1c786100719dcee71edb7e980679922ff1753519edfffbd9ca33a7c874d72cd4L67-R69) [[7]](diffhunk://#diff-1c786100719dcee71edb7e980679922ff1753519edfffbd9ca33a7c874d72cd4L87-R89)
* Enhanced async support: Changed `ProcessCurrentQueue` to an async method `ProcessCurrentQueueAsync` in `NetworkRequestManager` and its interface, and updated the timer callback to handle exceptions safely. [[1]](diffhunk://#diff-ac602d73bf4154598679a3b4a1e6696f95fc4319078e8ac2ed78faf9abba0a48L103-R105) [[2]](diffhunk://#diff-dcf1cd1e22f8f7cbdc5597777bb546e23e0fa12ef3be4b836d140dccf89d28f2L87-R88) [[3]](diffhunk://#diff-dcf1cd1e22f8f7cbdc5597777bb546e23e0fa12ef3be4b836d140dccf89d28f2L105-R112) [[4]](diffhunk://#diff-dcf1cd1e22f8f7cbdc5597777bb546e23e0fa12ef3be4b836d140dccf89d28f2L223-R257)

**Diagnostics robustness:**

* Improved exception handling in `AppDiagnostics` by wrapping last-resort exception handlers in try/catch blocks to prevent process crashes from unhandled exceptions. [[1]](diffhunk://#diff-c74f7cb80b6e6fcac08acdf6e8d73e8421f96756e4a4ea5811fa5201c45ea407R80-R81) [[2]](diffhunk://#diff-c74f7cb80b6e6fcac08acdf6e8d73e8421f96756e4a4ea5811fa5201c45ea407R97-R105) [[3]](diffhunk://#diff-c74f7cb80b6e6fcac08acdf6e8d73e8421f96756e4a4ea5811fa5201c45ea407R124-R128)

**Solution and project structure:**

* Added new test projects `MADE.Foundation.Tests` and `MADE.Runtime.Tests` to the solution, including their build and solution folder configuration. [[1]](diffhunk://#diff-008bbeb1f2d5088176eab8d6dc38ced0fe50336c97a2ac38df7701c512b41d3dR62-R65) [[2]](diffhunk://#diff-008bbeb1f2d5088176eab8d6dc38ced0fe50336c97a2ac38df7701c512b41d3dR176-R183) [[3]](diffhunk://#diff-008bbeb1f2d5088176eab8d6dc38ced0fe50336c97a2ac38df7701c512b41d3dR215-R216)

Other minor improvements include making the `GetQueryValue` extension method return a nullable string and passing cancellation tokens to `ReadAsStringAsync` for better cancellation support. [[1]](diffhunk://#diff-ee3698dc8a9d866f09d8a2c7314c7f563112cd8cf96ab93a388a5ed84fe45d17L20-R20) [[2]](diffhunk://#diff-8939d359eba884fec459ce0cfdc5cf4cbba971cad926b131ed8bbf85114ed566L121-R123) [[3]](diffhunk://#diff-1c786100719dcee71edb7e980679922ff1753519edfffbd9ca33a7c874d72cd4L121-R123)